### PR TITLE
fix: Search Icon

### DIFF
--- a/src/.vuepress/styles/index.styl
+++ b/src/.vuepress/styles/index.styl
@@ -28,6 +28,11 @@
   border-top: none !important;
 }
 
+// Show the magnifying glass search icon
+.search-box input {
+  background: #000 url(/assets/img/search.83621669.svg) .6rem .5rem no-repeat !important;
+}
+
 a {
   border-color: #4242c7 !important;
   // color: #4242c7 !important;


### PR DESCRIPTION
## Overview

Makes the search icon visible again:
<img width="230" alt="Screen Shot 2022-07-22 at 7 57 00 AM" src="https://user-images.githubusercontent.com/21288394/180434433-4563febc-5198-46c2-acdf-120f32a0b78c.png">


