### PR TITLE
Opcode snippet uses 32bytes for addr instead of 20

### DIFF
--- a/src/tutorial/evm-basics/README.md
+++ b/src/tutorial/evm-basics/README.md
@@ -75,17 +75,17 @@ Instead of imagining a large 1 dimensional array like we did with memory, you ca
 
 #### Mnenomic Example
 ```plaintext
-PUSH32 0xdEaDbEeFdEaDbEeFdEaDbEeFdEaDbEeFdEaDbEeFdEaDbEeFdEaDbEeFdEaDbEeF // [dead_addr]
-PUSH1 0x00                                                                // [0x00, dead_addr]
-SSTORE                                                                    // []
+PUSH20 0xdEaDbEeFdEaDbEeFdEaDbEeFdEaDbEeFdEaDbEeF // [dead_addr]
+PUSH1 0x00                                        // [0x00, dead_addr]
+SSTORE                                            // []
 
-PUSH32 0xC0FFEE0000000000000000000000000000000000000000000000000000000000 // [coffee_addr]
-PUSH1 0x01                                                                // [0x01, coffee_addr]
-SSTORE                                                                    // []
+PUSH20 0xC0FFEE0000000000000000000000000000000000 // [coffee_addr]
+PUSH1 0x01                                        // [0x01, coffee_addr]
+SSTORE                                            // []
 
 // Storage:
-// 0x00 -> deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
-// 0x01 -> c0ffee0000000000000000000000000000000000000000000000000000000000
+// 0x00 -> deadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+// 0x01 -> c0ffee0000000000000000000000000000000000
 
 PUSH1 0x00
 SLOAD                                                                     // [dead_addr]


### PR DESCRIPTION
The Mnemonic Example in lines 76-94 discusses pushing [dead_addr] and [coffee_addr] to the stack followed by the SSTORE opcode, but the values pushed are 32 bytes long (using PUSH32 opcode). This conflicts with the names given to them (addr implies a label of address type).

These values should instead be 20 bytes long and make use of the PUSH20 opcode, since 20 bytes is the correct byte length for EVM address types. I have updated the opcodes used and the values of the stack as well as the resulting value in storage shown by comments in lines 86-88.