### PR TITLE
Documentation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 ## Usage
 
+Install dependencies by running `yarn install`.
+
 Build the vuepress site by running `yarn build`.
 
 To run the site locally, execute `yarn dev`.

--- a/src/tutorial/simple-storage/README.md
+++ b/src/tutorial/simple-storage/README.md
@@ -101,8 +101,8 @@ To call our new macros from external functions we have to create a dispatcher!
     // Get the function selector
     0x00 calldataload 0xe0 shr
 
-    dup1 0x55241077 eq setValue jumpi // Compare function selector to setValue(uint256)
-    dup1 0x20965255 eq getValue jumpi // Compare the function selector to getValue()
+    dup1 __FUNC_SIG(setValue) eq setValue jumpi // Compare function selector to setValue(uint256)
+    dup1 __FUNC_SIG(getValue) eq getValue jumpi // Compare the function selector to getValue()
 
     // dispatch
     setValue:


### PR DESCRIPTION
Small fix so people unfamiliar with yarn will install dependencies before they build. Second fix is to the simple storage tutorial so `__FUNC_SIG` is used rather than the hex bytes for the function selector. This matches the rest of the tutorial and also the huff-template.