### PR TITLE
fix bug in `SET_VALUE()`

### DIFF
--- a/src/tutorial/simple-storage/README.md
+++ b/src/tutorial/simple-storage/README.md
@@ -70,6 +70,7 @@ Onto the fun part, the logic. Remember from the addTwo example we can read calld
     // Get pointer and store
     [VALUE]         // [value_ptr, value]
     sstore          // []
+    stop            // []
 }
 ```
 
@@ -134,6 +135,7 @@ Now all of it together!
     // Get pointer and store
     [VALUE]         // [value_ptr, value]
     sstore          // []
+    stop            // []
 }
 
 // getValue()


### PR DESCRIPTION
Previously, the `SET_VALUE()` method is not terminated correctly. Calling SET_VALUE() will continue to call `GET_VALUE()`. 

A `Stop` opcode needs to be added at the end of `SET_VALUE()`.