### PR TITLE
stop if the basic selector doesn't match

### DIFF
--- a/src/tutorial/the-basics/README.md
+++ b/src/tutorial/the-basics/README.md
@@ -140,6 +140,9 @@ To accept external calls for multiple functions we will have to extract our `add
 
     // Jump to the implementation of the ADD_TWO function if the calldata matches the function selector
     __FUNC_SIG(addTwo) eq addTwo jumpi
+    
+    // Stop execution if the calldata doesn't match the function selector
+    stop
 
     addTwo:
         ADD_TWO()


### PR DESCRIPTION
Otherwise, I can define a `thisFunctionDoesntExist(uint256, uint256) view returns(uint256)` function on the test interface, and call `addTwo.thisFunctionDoesntExist(1,2)` and still get the `addTwo` execution.